### PR TITLE
Add a Riak configuration function

### DIFF
--- a/include/riak_logger_config.hrl
+++ b/include/riak_logger_config.hrl
@@ -19,10 +19,11 @@
 
 -type config_map() :: any().
 -type config_fetch_fun() ::
-    fun((string(), config_map()) -> list()|pos_integer()).
+    fun((string(), config_map()) -> list()|pos_integer()|atom()).
 -type standard_handler() ::
     {handler, atom(), logger_std_h, map()}.
 
+-define(LOGGER_LEVEL_CFGKEY, "logger.level").
 -define(FILE_CONSOLE_CFGKEY, "logger.file").
 -define(FILE_ERROR_CFGKEY, "logger.error_file").
 -define(FILE_CRASH_CFGKEY, "logger.crash_file").

--- a/include/riak_logger_config.hrl
+++ b/include/riak_logger_config.hrl
@@ -19,11 +19,10 @@
 
 -type config_map() :: any().
 -type config_fetch_fun() ::
-    fun((string(), config_map()) -> list()|pos_integer()|atom()).
+    fun((string(), config_map()) -> list()|pos_integer()).
 -type standard_handler() ::
     {handler, atom(), logger_std_h, map()}.
 
--define(LOGGER_LEVEL_CFGKEY, "logger.level").
 -define(FILE_CONSOLE_CFGKEY, "logger.file").
 -define(FILE_ERROR_CFGKEY, "logger.error_file").
 -define(FILE_CRASH_CFGKEY, "logger.crash_file").

--- a/include/riak_logger_config.hrl
+++ b/include/riak_logger_config.hrl
@@ -1,0 +1,39 @@
+%% -*- mode: erlang; erlang-indent-level: 4; indent-tabs-mode: nil -*-
+%% -------------------------------------------------------------------
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-type config_map() :: any().
+-type config_fetch_fun() ::
+    fun((string(), config_map()) -> list()|pos_integer()).
+-type standard_handler() ::
+    {handler, atom(), logger_std_h, map()}.
+
+-define(FILE_CONSOLE_CFGKEY, "logger.file").
+-define(FILE_ERROR_CFGKEY, "error.file").
+-define(FILE_CRASH_CFGKEY, "crash.file").
+-define(FILE_REPORT_CFGKEY, "report.file").
+-define(FILE_BACKEND_CFGKEY, "backend.file").
+-define(FILE_BACKGROUND_CFGKEY, "background.file").
+-define(FILE_JSON_CFGKEY, "json.file").
+-define(MAX_FILESIZE_CFGKEY, "logger.max_file_size").
+-define(MAX_FILECOUNT_CFGKEY, "logger.max_files").
+-define(DEFAULT_FORMAT_CFGKEY, "logger.format").
+-define(DEFAULT_FILTERS_CFGKEY, "logger.default_filters").
+-define(ADDITIONAL_HANDLERS_CFGKEY, "logger.additional_handlers").
+
+-define(STANDARD_FILTERS, [crash, error, progress, report, sasl]).

--- a/include/riak_logger_config.hrl
+++ b/include/riak_logger_config.hrl
@@ -24,12 +24,12 @@
     {handler, atom(), logger_std_h, map()}.
 
 -define(FILE_CONSOLE_CFGKEY, "logger.file").
--define(FILE_ERROR_CFGKEY, "error.file").
--define(FILE_CRASH_CFGKEY, "crash.file").
--define(FILE_REPORT_CFGKEY, "report.file").
--define(FILE_BACKEND_CFGKEY, "backend.file").
--define(FILE_BACKGROUND_CFGKEY, "background.file").
--define(FILE_JSON_CFGKEY, "json.file").
+-define(FILE_ERROR_CFGKEY, "logger.error_file").
+-define(FILE_CRASH_CFGKEY, "logger.crash_file").
+-define(FILE_REPORT_CFGKEY, "logger.report_file").
+-define(FILE_BACKEND_CFGKEY, "logger.backend_file").
+-define(FILE_BACKGROUND_CFGKEY, "logger.background_file").
+-define(FILE_JSON_CFGKEY, "logger.json_file").
 -define(MAX_FILESIZE_CFGKEY, "logger.max_file_size").
 -define(MAX_FILECOUNT_CFGKEY, "logger.max_files").
 -define(DEFAULT_FORMAT_CFGKEY, "logger.format").

--- a/src/riak_logger_config.erl
+++ b/src/riak_logger_config.erl
@@ -130,13 +130,6 @@ conf_getatomlist(Key, ConfFetchFun, Conf) ->
             )
     end.
 
--spec conf_getatom(string(), config_fetch_fun(), config_map()) -> atom().
-conf_getatom(Key, ConfFetchFun, Conf) ->
-    case ConfFetchFun(Key, Conf) of
-        A when erlang:is_atom(A) ->
-            A
-    end.
-
 -spec parse_inputs(config_fetch_fun(), config_map()) ->
     {
         ok,
@@ -248,8 +241,7 @@ get_handler(backend, ConfFun, Conf, MaxNumBytes, MaxNumFiles, FormatTerm) ->
         MaxNumBytes,
         MaxNumFiles,
         FormatTerm,
-        backend,
-        conf_getatom(?LOGGER_LEVEL_CFGKEY, ConfFun, Conf)
+        backend
     );
 get_handler(background, ConfFun, Conf, MaxNumBytes, MaxNumFiles, FormatTerm) ->
     domain_handler(
@@ -257,8 +249,7 @@ get_handler(background, ConfFun, Conf, MaxNumBytes, MaxNumFiles, FormatTerm) ->
         MaxNumBytes,
         MaxNumFiles,
         FormatTerm,
-        background,
-        conf_getatom(?LOGGER_LEVEL_CFGKEY, ConfFun, Conf)
+        background
     );
 get_handler(json, ConfFun, Conf, MaxNumBytes, MaxNumFiles, _FormatTerm) ->
     json_handler(
@@ -381,13 +372,13 @@ report_handler(File, MaxNumBytes, MaxNumFiles, FormatTerm) ->
         }
     }.
 
-domain_handler(File, MaxNumBytes, MaxNumFiles, FormatTerm, Domain, DLL) ->
+domain_handler(File, MaxNumBytes, MaxNumFiles, FormatTerm, Domain) ->
     {
         handler,
         Domain,
         logger_std_h,
         #{
-            level => DLL,
+            level => all,
             config =>
                 standard_config(File, MaxNumBytes, MaxNumFiles),
             filter_default => stop,
@@ -705,7 +696,6 @@ domain_config_test() ->
     ConfFetchFun = fun(Key, Map) -> maps:get(Key, Map) end,
     Conf1 =
         #{
-            ?LOGGER_LEVEL_CFGKEY => info,
             ?FILE_CONSOLE_CFGKEY => "/var/log/riak/console.log",
             ?FILE_CRASH_CFGKEY => "/var/log/riak/crash.log",
             ?FILE_ERROR_CFGKEY => "/var/log/riak/error.log",
@@ -747,7 +737,7 @@ domain_config_test() ->
             backend,
             logger_std_h,
             #{
-                level => info,
+                level => all,
                 config =>
                     standard_config("/var/log/riak/backend.log", 1048576, 10),
                 filter_default => stop,
@@ -771,7 +761,7 @@ domain_config_test() ->
             background,
             logger_std_h,
             #{
-                level => info,
+                level => all,
                 config =>
                     standard_config("/var/log/riak/async.log", 1048576, 10),
                 filter_default => stop,

--- a/src/riak_logger_config.erl
+++ b/src/riak_logger_config.erl
@@ -130,6 +130,13 @@ conf_getatomlist(Key, ConfFetchFun, Conf) ->
             )
     end.
 
+-spec conf_getatom(string(), config_fetch_fun(), config_map()) -> atom().
+conf_getatom(Key, ConfFetchFun, Conf) ->
+    case ConfFetchFun(Key, Conf) of
+        A when erlang:is_atom(A) ->
+            A
+    end.
+
 -spec parse_inputs(config_fetch_fun(), config_map()) ->
     {
         ok,
@@ -241,7 +248,8 @@ get_handler(backend, ConfFun, Conf, MaxNumBytes, MaxNumFiles, FormatTerm) ->
         MaxNumBytes,
         MaxNumFiles,
         FormatTerm,
-        backend
+        backend,
+        conf_getatom(?LOGGER_LEVEL_CFGKEY, ConfFun, Conf)
     );
 get_handler(background, ConfFun, Conf, MaxNumBytes, MaxNumFiles, FormatTerm) ->
     domain_handler(
@@ -249,7 +257,8 @@ get_handler(background, ConfFun, Conf, MaxNumBytes, MaxNumFiles, FormatTerm) ->
         MaxNumBytes,
         MaxNumFiles,
         FormatTerm,
-        background
+        background,
+        conf_getatom(?LOGGER_LEVEL_CFGKEY, ConfFun, Conf)
     );
 get_handler(json, ConfFun, Conf, MaxNumBytes, MaxNumFiles, _FormatTerm) ->
     json_handler(
@@ -372,13 +381,13 @@ report_handler(File, MaxNumBytes, MaxNumFiles, FormatTerm) ->
         }
     }.
 
-domain_handler(File, MaxNumBytes, MaxNumFiles, FormatTerm, Domain) ->
+domain_handler(File, MaxNumBytes, MaxNumFiles, FormatTerm, Domain, DLL) ->
     {
         handler,
         Domain,
         logger_std_h,
         #{
-            level => all,
+            level => DLL,
             config =>
                 standard_config(File, MaxNumBytes, MaxNumFiles),
             filter_default => stop,
@@ -696,6 +705,7 @@ domain_config_test() ->
     ConfFetchFun = fun(Key, Map) -> maps:get(Key, Map) end,
     Conf1 =
         #{
+            ?LOGGER_LEVEL_CFGKEY => info,
             ?FILE_CONSOLE_CFGKEY => "/var/log/riak/console.log",
             ?FILE_CRASH_CFGKEY => "/var/log/riak/crash.log",
             ?FILE_ERROR_CFGKEY => "/var/log/riak/error.log",
@@ -737,7 +747,7 @@ domain_config_test() ->
             backend,
             logger_std_h,
             #{
-                level => all,
+                level => info,
                 config =>
                     standard_config("/var/log/riak/backend.log", 1048576, 10),
                 filter_default => stop,
@@ -761,7 +771,7 @@ domain_config_test() ->
             background,
             logger_std_h,
             #{
-                level => all,
+                level => info,
                 config =>
                     standard_config("/var/log/riak/async.log", 1048576, 10),
                 filter_default => stop,

--- a/src/riak_logger_config.erl
+++ b/src/riak_logger_config.erl
@@ -44,7 +44,11 @@ handler_config(Conf, ConfFetchFun) ->
             }
         } ->
             AdditionalHandlers =
-                conf_getlist(?ADDITIONAL_HANDLERS_CFGKEY, ConfFetchFun, Conf),
+                conf_getatomlist(
+                    ?ADDITIONAL_HANDLERS_CFGKEY,
+                    ConfFetchFun,
+                    Conf
+                ),
             DomainFilters =
                 lists:map(
                     fun(F) ->
@@ -79,7 +83,11 @@ handler_config(Conf, ConfFetchFun) ->
                 ),
             OtherHandlers =
                 lists:map(
-                    fun(H) ->
+                    fun(H)
+                        when 
+                            H == crash; H == error; H == report;
+                            H == background; H == backend;
+                            H == json ->
                         get_handler(
                             H,
                             ConfFetchFun,
@@ -106,7 +114,21 @@ conf_getlist(Key, ConfFetchFun, Conf) ->
     case ConfFetchFun(Key, Conf) of
         L when erlang:is_list(L) ->
             L
-    end.    
+    end.
+
+-spec conf_getatomlist(
+    string(), config_fetch_fun(), config_map()) -> list(atom()).
+conf_getatomlist(Key, ConfFetchFun, Conf) ->
+    case ConfFetchFun(Key, Conf) of
+        L when erlang:is_list(L) ->
+            Tokens = string:lexemes(L, "|"),
+            lists:map(
+                fun(T) -> 
+                    erlang:list_to_atom(string:lowercase(T))
+                end,
+                Tokens
+            )
+    end.
 
 -spec parse_inputs(config_fetch_fun(), config_map()) ->
     {
@@ -114,7 +136,7 @@ conf_getlist(Key, ConfFetchFun, Conf) ->
         {
             list(term()), 
             list(tuple()),
-            list(additional_handlers()),
+            list(atom()),
             pos_integer(),
             pos_integer()
         }
@@ -124,7 +146,7 @@ parse_inputs(ConfFetchFun, Conf) ->
     case parse_logformat(ConfigFormat) of
         {ok, DefaultFormatTerm} ->
             DefaultFilters =
-                conf_getlist(?DEFAULT_FILTERS_CFGKEY, ConfFetchFun, Conf),
+                conf_getatomlist(?DEFAULT_FILTERS_CFGKEY, ConfFetchFun, Conf),
             NonStandardFilters = DefaultFilters -- ?STANDARD_FILTERS,
             StandardFilters = DefaultFilters -- NonStandardFilters,
             DefaultFilter =
@@ -505,8 +527,8 @@ classic_config_test() ->
             ?DEFAULT_FORMAT_CFGKEY => 
                 "[time,\" [\",level,\"] \",pid,\"@\",mfa,"
                 "\":\",line,\" \",msg,\"\\n\"].",
-            ?DEFAULT_FILTERS_CFGKEY => [crash, error, sasl],
-            ?ADDITIONAL_HANDLERS_CFGKEY => [crash, error, report]
+            ?DEFAULT_FILTERS_CFGKEY => "crash|error|sasl",
+            ?ADDITIONAL_HANDLERS_CFGKEY => "crash|error|report"
         },
     {ok, ClassicConfig} = handler_config(Conf1, ConfFetchFun),
 
@@ -640,8 +662,8 @@ json_config_test() ->
             ?DEFAULT_FORMAT_CFGKEY => 
                 "[time,\" [\",level,\"] \",pid,\"@\",mfa,"
                 "\":\",line,\" \",msg,\"\\n\"].",
-            ?DEFAULT_FILTERS_CFGKEY => [crash, error, sasl],
-            ?ADDITIONAL_HANDLERS_CFGKEY => [crash, error, report, json]
+            ?DEFAULT_FILTERS_CFGKEY => "crash|error|sasl",
+            ?ADDITIONAL_HANDLERS_CFGKEY => "crash|error|report|json"
         },
     {ok, JsonConfig} = handler_config(Conf1, ConfFetchFun),
 
@@ -686,9 +708,9 @@ domain_config_test() ->
                 "[time,\" [\",level,\"] \",pid,\"@\",mfa,"
                 "\":\",line,\" \",msg,\"\\n\"].",
             ?DEFAULT_FILTERS_CFGKEY =>
-                [crash, error, sasl, backend, background],
+                "crash|error|sasl|backend|background",
             ?ADDITIONAL_HANDLERS_CFGKEY =>
-                [crash, error, report, backend, background]
+                "crash|error|report|backend|background"
         },
     {ok, DomainConfig} = handler_config(Conf1, ConfFetchFun),
 

--- a/src/riak_logger_config.erl
+++ b/src/riak_logger_config.erl
@@ -121,7 +121,7 @@ conf_getlist(Key, ConfFetchFun, Conf) ->
 conf_getatomlist(Key, ConfFetchFun, Conf) ->
     case ConfFetchFun(Key, Conf) of
         AL when erlang:is_list(AL) ->
-            AL
+            lists:filter(fun(A) -> A =/= none end, AL)
     end.
 
 -spec parse_inputs(config_fetch_fun(), config_map()) ->
@@ -452,8 +452,8 @@ simple_config_test() ->
             ?DEFAULT_FORMAT_CFGKEY => 
                 "[time,\" [\",level,\"] \",pid,\"@\",mfa,"
                 "\":\",line,\" \",msg,\"\\n\"].",
-            ?DEFAULT_FILTERS_CFGKEY => [],
-            ?ADDITIONAL_HANDLERS_CFGKEY => []
+            ?DEFAULT_FILTERS_CFGKEY => [none],
+            ?ADDITIONAL_HANDLERS_CFGKEY => [none]
         },
     {ok, SimpleConfig} = handler_config(Conf, ConfFetchFun),
 
@@ -500,8 +500,8 @@ error_config_test() ->
             ?DEFAULT_FORMAT_CFGKEY => 
                 "[time,\" [\",level,\"] \",pid,\"@\",mfa,"
                 "\":\",line,\" \",msg,\"\\n\"].",
-            ?DEFAULT_FILTERS_CFGKEY => [],
-            ?ADDITIONAL_HANDLERS_CFGKEY => []
+            ?DEFAULT_FILTERS_CFGKEY => [none],
+            ?ADDITIONAL_HANDLERS_CFGKEY => [none]
         },
     ?assertMatch(
         {error, "Invalid file size 0 or count 10"},

--- a/src/riak_logger_config.erl
+++ b/src/riak_logger_config.erl
@@ -1,0 +1,767 @@
+%% -*- mode: erlang; erlang-indent-level: 4; indent-tabs-mode: nil -*-
+%% -------------------------------------------------------------------
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_logger_config).
+
+-export([handler_config/2]).
+
+-include("riak_logger_config.hrl").
+
+-type additional_handlers() ::
+    crash | error | report | backend | background | json.
+
+-spec handler_config(
+    config_map(), config_fetch_fun()) ->
+        {ok, list(standard_handler())} | {error, term()}.
+handler_config(Conf, ConfFetchFun) ->
+    case parse_inputs(ConfFetchFun, Conf) of
+        {error, Term} ->
+            {error, Term};
+        {
+            ok, 
+            {
+                DefaultFormatTerm,
+                DefaultFilter,
+                NonStandardFilters,
+                MaxNumBytes,
+                MaxNumFiles
+            }
+        } ->
+            AdditionalHandlers =
+                conf_getlist(?ADDITIONAL_HANDLERS_CFGKEY, ConfFetchFun, Conf),
+            DomainFilters =
+                lists:map(
+                    fun(F) ->
+                        case F of
+                            backend ->
+                                {
+                                    backend_filter,
+                                    {
+                                        fun logger_filters:domain/2,
+                                        {stop, sub, [backend]}
+                                    }
+                                };
+                            background ->
+                                {
+                                    background_filter,
+                                    {
+                                    fun logger_filters:domain/2,
+                                    {stop, sub, [background]}
+                                    }
+                                }
+                        end
+                    end,
+                    NonStandardFilters
+                ),
+            DefaultHandler =
+                console_handler(
+                    conf_getlist(?FILE_CONSOLE_CFGKEY, ConfFetchFun, Conf),
+                    MaxNumBytes,
+                    MaxNumFiles,
+                    DefaultFormatTerm,
+                    DomainFilters ++ DefaultFilter
+                ),
+            OtherHandlers =
+                lists:map(
+                    fun(H) ->
+                        get_handler(
+                            H,
+                            ConfFetchFun,
+                            Conf,
+                            MaxNumBytes,
+                            MaxNumFiles,
+                            DefaultFormatTerm
+                        )
+                    end,
+                AdditionalHandlers
+                ),
+            {ok, [DefaultHandler] ++ OtherHandlers}
+    end.
+
+-spec conf_getint(string(), config_fetch_fun(), config_map()) -> integer().
+conf_getint(Key, ConfFetchFun, Conf) ->
+    case ConfFetchFun(Key, Conf) of
+        I when erlang:is_integer(I) ->
+            I
+    end.
+
+-spec conf_getlist(string(), config_fetch_fun(), config_map()) -> list().
+conf_getlist(Key, ConfFetchFun, Conf) ->
+    case ConfFetchFun(Key, Conf) of
+        L when erlang:is_list(L) ->
+            L
+    end.    
+
+-spec parse_inputs(config_fetch_fun(), config_map()) ->
+    {
+        ok,
+        {
+            list(term()), 
+            list(tuple()),
+            list(additional_handlers()),
+            pos_integer(),
+            pos_integer()
+        }
+    } | {error, term()}.
+parse_inputs(ConfFetchFun, Conf) ->
+    ConfigFormat = conf_getlist(?DEFAULT_FORMAT_CFGKEY, ConfFetchFun, Conf),
+    case parse_logformat(ConfigFormat) of
+        {ok, DefaultFormatTerm} ->
+            DefaultFilters =
+                conf_getlist(?DEFAULT_FILTERS_CFGKEY, ConfFetchFun, Conf),
+            NonStandardFilters = DefaultFilters -- ?STANDARD_FILTERS,
+            StandardFilters = DefaultFilters -- NonStandardFilters,
+            DefaultFilter =
+                case lists:usort(StandardFilters) of
+                    [crash] ->
+                        [{default_filter, {fun riak_logger:filter_c/2, stop}}];
+                    [crash, error] ->
+                        [{default_filter, {fun riak_logger:filter_ce/2, stop}}];
+                    [crash, error, progress] ->
+                        [{default_filter, {fun riak_logger:filter_cep/2, stop}}];
+                    [crash, error, progress, sasl] ->
+                        [{default_filter, {fun riak_logger:filter_ceps/2, stop}}];
+                    [crash, error, progress, report, sasl] ->
+                        [{default_filter, {fun riak_logger:filter_ceprs/2, stop}}];
+                    [crash, error, sasl] ->
+                        [{default_filter, {fun riak_logger:filter_ces/2, stop}}];
+                    [] ->
+                        [];
+                    UnsupportedCombination ->
+                        format_error(
+                            <<"Unsupported filter combination ~0p">>,
+                            [UnsupportedCombination]
+                        )
+                end,
+            case {
+                    DefaultFilter,
+                    conf_getint(?MAX_FILESIZE_CFGKEY, ConfFetchFun, Conf),
+                    conf_getint(?MAX_FILECOUNT_CFGKEY, ConfFetchFun, Conf)
+                } of
+                {{error, Term}, _, _} ->
+                    {error, Term};
+                {Filter, MaxNumBytes, MaxNumFiles}
+                        when
+                            erlang:is_integer(MaxNumBytes), MaxNumBytes > 0,
+                            erlang:is_integer(MaxNumFiles), MaxNumFiles > 0 ->
+                    {
+                        ok, 
+                        {
+                            DefaultFormatTerm,
+                            Filter,
+                            NonStandardFilters,
+                            MaxNumBytes,
+                            MaxNumFiles
+                        }
+                    };
+                {_Filter, MaxNumBytes, MaxNumFiles} ->
+                    format_error(
+                        <<"Invalid file size ~0p or count ~0p">>,
+                        [MaxNumBytes, MaxNumFiles]
+                    )
+            end;
+        {error, UnexpectedResult} ->
+            format_error(
+                <<"Parsing error of format string ~0p">>,
+                [UnexpectedResult]
+            )
+    end.
+
+-spec get_handler(
+    additional_handlers(),
+    config_fetch_fun(),
+    config_map(),
+    pos_integer(),
+    pos_integer(),
+    list(term())
+)
+    -> standard_handler().
+get_handler(crash, ConfFun, Conf, MaxNumBytes, MaxNumFiles, FormatTerm) ->
+    crash_handler(
+        conf_getlist(?FILE_CRASH_CFGKEY, ConfFun, Conf),
+        MaxNumBytes,
+        MaxNumFiles,
+        FormatTerm
+    );
+get_handler(error, ConfFun, Conf, MaxNumBytes, MaxNumFiles, FormatTerm) ->
+    error_handler(
+        conf_getlist(?FILE_ERROR_CFGKEY, ConfFun, Conf),
+        MaxNumBytes,
+        MaxNumFiles,
+        FormatTerm
+    );
+get_handler(report, ConfFun, Conf, MaxNumBytes, MaxNumFiles, FormatTerm) ->
+    report_handler(
+        conf_getlist(?FILE_REPORT_CFGKEY, ConfFun, Conf),
+        MaxNumBytes,
+        MaxNumFiles,
+        FormatTerm
+    );
+get_handler(backend, ConfFun, Conf, MaxNumBytes, MaxNumFiles, FormatTerm) ->
+    domain_handler(
+        conf_getlist(?FILE_BACKEND_CFGKEY, ConfFun, Conf),
+        MaxNumBytes,
+        MaxNumFiles,
+        FormatTerm,
+        backend
+    );
+get_handler(background, ConfFun, Conf, MaxNumBytes, MaxNumFiles, FormatTerm) ->
+    domain_handler(
+        conf_getlist(?FILE_BACKGROUND_CFGKEY, ConfFun, Conf),
+        MaxNumBytes,
+        MaxNumFiles,
+        FormatTerm,
+        background
+    );
+get_handler(json, ConfFun, Conf, MaxNumBytes, MaxNumFiles, _FormatTerm) ->
+    json_handler(
+        conf_getlist(?FILE_JSON_CFGKEY, ConfFun, Conf),
+        MaxNumBytes,
+        MaxNumFiles
+    ).
+
+-spec standard_config(
+    string(), pos_integer(), pos_integer()) -> #{atom() => any()}.
+standard_config(File, MaxNumBytes, MaxNumFiles) ->
+    #{
+        file => File,
+        file_check => 100,
+        max_no_bytes => MaxNumBytes,
+        max_no_files => MaxNumFiles
+    }.
+
+-spec standard_formatter(boolean(), list(term())) -> #{atom() => any()}.
+standard_formatter(SingleLine, FormatTerm) ->
+    #{
+        legacy_header => false,
+        single_line => SingleLine,
+        time_designator => $\s,
+        template => FormatTerm
+    }.
+
+-spec format_error(binary(), list()) -> {error, string()}.
+format_error(Text, Subs) ->
+    {
+        error,
+        lists:flatten(io_lib:format(Text, Subs))
+    }.
+
+console_handler(File, MaxNumBytes, MaxNumFiles, FormatTerm, Filters) ->
+    {
+        handler,
+        default,
+        logger_std_h,
+        #{
+            level => all,
+            config =>
+                standard_config(File, MaxNumBytes, MaxNumFiles),
+            filter_default => log,
+            filters => Filters,
+            formatter =>
+                {
+                    logger_formatter,
+                    standard_formatter(true, FormatTerm)
+                }
+        }
+    }.
+
+error_handler(File, MaxNumBytes, MaxNumFiles, FormatTerm) ->
+    %% Records all events at 'error' level or higher
+    {
+        handler,
+        error_log,
+        logger_std_h,
+        #{
+            level => error,
+            config =>
+                standard_config(File, MaxNumBytes, MaxNumFiles),
+            filter_default => log,
+            filters => [],
+            formatter =>
+                {
+                    logger_formatter,
+                    standard_formatter(true, FormatTerm)
+                }
+        }
+    }.
+
+crash_handler(File, MaxNumBytes, MaxNumFiles, FormatTerm) ->
+    %% Records process crashes
+    {
+        handler,
+        crash_log,
+        logger_std_h,
+        #{
+            level => all,
+            config =>
+                standard_config(File, MaxNumBytes, MaxNumFiles),
+            filter_default => stop,
+            filters => 
+                [
+                    {crash_filter, {fun riak_logger:filter_ce/2, log}}
+                ],
+        formatter =>
+            {
+                logger_formatter,
+                standard_formatter(false, FormatTerm)
+            }
+        }
+    }.
+
+report_handler(File, MaxNumBytes, MaxNumFiles, FormatTerm) ->
+    %% Records progress and SASL reports
+    {
+        handler,
+        report_log,
+        logger_std_h,
+        #{
+            level => info,
+            config =>
+                standard_config(File, MaxNumBytes, MaxNumFiles),
+            filter_default => stop,
+            filters =>
+                [
+                    {
+                        report_filter,
+                        {fun riak_logger:filter_ps/2, log}
+                    }
+                ],
+            formatter =>
+                {
+                    logger_formatter,
+                    standard_formatter(false, FormatTerm)
+                }
+        }
+    }.
+
+domain_handler(File, MaxNumBytes, MaxNumFiles, FormatTerm, Domain) ->
+    {
+        handler,
+        Domain,
+        logger_std_h,
+        #{
+            level => all,
+            config =>
+                standard_config(File, MaxNumBytes, MaxNumFiles),
+            filter_default => stop,
+            filters => 
+                [
+                    {
+                        domain_filter,
+                        {fun logger_filters:domain/2, {log, sub, [Domain]}}
+                    }
+                ],
+            formatter =>
+                {
+                    logger_formatter,
+                    standard_formatter(true, FormatTerm)
+                }
+        }
+    }.
+
+json_handler(File, MaxNumBytes, MaxNumFiles) ->
+    {
+        handler,
+        json_log,
+        logger_std_h,
+        #{
+            level => all,
+            config =>
+                #{
+                    compress_on_rotate => false,
+                    file => File,
+                    file_check => 100,
+                    max_no_bytes => MaxNumBytes,
+                    max_no_files => MaxNumFiles
+                },
+            filter_default => log,
+            filters => [],
+            formatter => 
+                {
+                    riak_log_json_formatter, #{}
+                %% Defaults should be suitable for most use cases.
+                }
+        }
+    }.
+
+
+%% ===================================================================
+%% Config Functions - to be used in riak_logger_config-* modules
+%% ===================================================================
+
+-spec parse_logformat(list()) -> {ok, list(term())}|{error, term()}.
+parse_logformat(LogFormatStr) ->
+    {ok, LogTokens, _} = erl_scan:string(LogFormatStr),
+    case erl_parse:parse_term(LogTokens) of
+        {ok, LogFormatTerm} when erlang:is_list(LogFormatTerm) ->
+            {ok, LogFormatTerm};
+        UnexpectedResult ->
+            {error, UnexpectedResult}
+    end.
+
+%% ===================================================================
+%% Unit tests
+%% ===================================================================
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+standard_template() ->
+    [time," [",level,"] ",pid,"@",mfa,":",line," ",msg,"\n"].
+
+simple_config_test() ->
+    ConfFetchFun = fun(Key, Map) -> maps:get(Key, Map) end,
+    Conf =
+        #{
+            ?FILE_CONSOLE_CFGKEY => "/var/log/riak/console.log",
+            ?MAX_FILECOUNT_CFGKEY => 10,
+            ?MAX_FILESIZE_CFGKEY => 1024 * 1024,
+            ?DEFAULT_FORMAT_CFGKEY => 
+                "[time,\" [\",level,\"] \",pid,\"@\",mfa,"
+                "\":\",line,\" \",msg,\"\\n\"].",
+            ?DEFAULT_FILTERS_CFGKEY => [],
+            ?ADDITIONAL_HANDLERS_CFGKEY => []
+        },
+    {ok, SimpleConfig} = handler_config(Conf, ConfFetchFun),
+
+    ExpectedConfig =
+        [
+            {
+                handler,
+                default,
+                logger_std_h,
+                #{
+                    config => 
+                        #{
+                            file => "/var/log/riak/console.log",
+                            file_check => 100,
+                            max_no_bytes => 1048576,
+                            max_no_files => 10
+                        },
+                    level => all,
+                    filters => [],
+                    filter_default => log,
+                    formatter => 
+                        {
+                            logger_formatter,
+                            #{
+                                legacy_header => false,
+                                single_line => true,
+                                template => standard_template(),
+                                time_designator => $\s
+                            }
+                        }
+                }
+            }
+        ],
+
+    ?assertMatch(ExpectedConfig, SimpleConfig).
+
+error_config_test() ->
+    ConfFetchFun = fun(Key, Map) -> maps:get(Key, Map) end,
+    Conf1 =
+        #{
+            ?FILE_CONSOLE_CFGKEY => "/var/log/riak/console.log",
+            ?MAX_FILECOUNT_CFGKEY => 10,
+            ?MAX_FILESIZE_CFGKEY => 0,
+            ?DEFAULT_FORMAT_CFGKEY => 
+                "[time,\" [\",level,\"] \",pid,\"@\",mfa,"
+                "\":\",line,\" \",msg,\"\\n\"].",
+            ?DEFAULT_FILTERS_CFGKEY => [],
+            ?ADDITIONAL_HANDLERS_CFGKEY => []
+        },
+    ?assertMatch(
+        {error, "Invalid file size 0 or count 10"},
+        handler_config(Conf1, ConfFetchFun)
+    ).
+
+classic_config_test() ->
+    ConfFetchFun = fun(Key, Map) -> maps:get(Key, Map) end,
+    Conf1 =
+        #{
+            ?FILE_CONSOLE_CFGKEY => "/var/log/riak/console.log",
+            ?FILE_CRASH_CFGKEY => "/var/log/riak/crash.log",
+            ?FILE_ERROR_CFGKEY => "/var/log/riak/error.log",
+            ?FILE_REPORT_CFGKEY => "/var/log/riak/report.log",
+            ?MAX_FILECOUNT_CFGKEY => 10,
+            ?MAX_FILESIZE_CFGKEY => 1024 * 1024,
+            ?DEFAULT_FORMAT_CFGKEY => 
+                "[time,\" [\",level,\"] \",pid,\"@\",mfa,"
+                "\":\",line,\" \",msg,\"\\n\"].",
+            ?DEFAULT_FILTERS_CFGKEY => [crash, error, sasl],
+            ?ADDITIONAL_HANDLERS_CFGKEY => [crash, error, report]
+        },
+    {ok, ClassicConfig} = handler_config(Conf1, ConfFetchFun),
+
+    ExpectedConfig = expected_classic_config(),
+        
+    ?assertMatch(ExpectedConfig, ClassicConfig).
+
+expected_classic_config() ->
+    [
+        {
+            handler,
+            default,
+            logger_std_h,
+            #{
+                config =>
+                    #{
+                        file => "/var/log/riak/console.log",
+                        file_check => 100,
+                        max_no_bytes => 1048576,
+                        max_no_files => 10
+                    },
+                level => all,
+                filters => [{default_filter,{fun riak_logger:filter_ces/2,stop}}],
+                filter_default => log,
+                formatter => 
+                    {
+                        logger_formatter,
+                        #{
+                            single_line => true,
+                            legacy_header => false,
+                            template => standard_template(),
+                            time_designator => $\s
+                        }
+                    }
+            }
+        },
+        {
+            handler,
+            crash_log,
+            logger_std_h,
+            #{
+                config => 
+                    #{
+                        file => "/var/log/riak/crash.log",
+                        file_check => 100,
+                        max_no_bytes => 1048576,
+                        max_no_files => 10
+                    },
+                level => all,
+                filters => [{crash_filter,{fun riak_logger:filter_ce/2,log}}],
+                filter_default => stop,
+                formatter => 
+                    {
+                        logger_formatter,
+                        #{
+                            single_line => false,
+                            legacy_header => false,
+                            template => standard_template(),
+                            time_designator => $\s
+                        }
+                    }
+            }
+        },
+        {
+            handler,
+            error_log,
+            logger_std_h,
+            #{
+                config =>
+                    #{
+                        file => "/var/log/riak/error.log",
+                        file_check => 100,
+                        max_no_bytes => 1048576,
+                        max_no_files => 10
+                    },
+                level => error,
+                filters => [],
+                filter_default => log,
+                formatter => 
+                    {
+                        logger_formatter,
+                        #{
+                            single_line => true,
+                            legacy_header => false,
+                            template => standard_template(),
+                            time_designator => $\s
+                        }
+                    }
+            }
+        },
+        {
+            handler,
+            report_log,
+            logger_std_h,
+            #{
+                config => 
+                    #{
+                        file => "/var/log/riak/report.log",
+                        file_check => 100,
+                        max_no_bytes => 1048576,
+                        max_no_files => 10
+                    },
+                    level => info,
+                    filters => [{report_filter,{fun riak_logger:filter_ps/2,log}}],
+                    filter_default => stop,
+                    formatter => 
+                        {
+                            logger_formatter,
+                            #{
+                                single_line => false,
+                                legacy_header => false,
+                                template => standard_template(),
+                                time_designator => $\s
+                            }
+                        }
+            }
+        }
+    ].
+
+json_config_test() ->
+    ConfFetchFun = fun(Key, Map) -> maps:get(Key, Map) end,
+    Conf1 =
+        #{
+            ?FILE_CONSOLE_CFGKEY => "/var/log/riak/console.log",
+            ?FILE_CRASH_CFGKEY => "/var/log/riak/crash.log",
+            ?FILE_ERROR_CFGKEY => "/var/log/riak/error.log",
+            ?FILE_REPORT_CFGKEY => "/var/log/riak/report.log",
+            ?FILE_JSON_CFGKEY => "{{platform_log_dir}}/json/riak-log.json",
+            ?MAX_FILECOUNT_CFGKEY => 10,
+            ?MAX_FILESIZE_CFGKEY => 1024 * 1024,
+            ?DEFAULT_FORMAT_CFGKEY => 
+                "[time,\" [\",level,\"] \",pid,\"@\",mfa,"
+                "\":\",line,\" \",msg,\"\\n\"].",
+            ?DEFAULT_FILTERS_CFGKEY => [crash, error, sasl],
+            ?ADDITIONAL_HANDLERS_CFGKEY => [crash, error, report, json]
+        },
+    {ok, JsonConfig} = handler_config(Conf1, ConfFetchFun),
+
+    ExpectedJsonHandler =
+        {
+            handler,
+            json_log,
+            logger_std_h, 
+            #{
+                level => all,
+                config => 
+                    #{
+                        compress_on_rotate => false,
+                        file => "{{platform_log_dir}}/json/riak-log.json",
+                        file_check => 100,
+                        max_no_bytes => 1048576,
+                        max_no_files => 10
+                    },
+                filter_default => log,
+                filters => [],
+                formatter => {riak_log_json_formatter, #{}}
+            }
+        },
+    
+    ExpectedConfig = expected_classic_config() ++ [ExpectedJsonHandler],
+
+    ?assertMatch(ExpectedConfig, JsonConfig).
+
+domain_config_test() ->
+    ConfFetchFun = fun(Key, Map) -> maps:get(Key, Map) end,
+    Conf1 =
+        #{
+            ?FILE_CONSOLE_CFGKEY => "/var/log/riak/console.log",
+            ?FILE_CRASH_CFGKEY => "/var/log/riak/crash.log",
+            ?FILE_ERROR_CFGKEY => "/var/log/riak/error.log",
+            ?FILE_REPORT_CFGKEY => "/var/log/riak/report.log",
+            ?FILE_BACKEND_CFGKEY => "/var/log/riak/backend.log",
+            ?FILE_BACKGROUND_CFGKEY => "/var/log/riak/async.log",
+            ?MAX_FILECOUNT_CFGKEY => 10,
+            ?MAX_FILESIZE_CFGKEY => 1024 * 1024,
+            ?DEFAULT_FORMAT_CFGKEY => 
+                "[time,\" [\",level,\"] \",pid,\"@\",mfa,"
+                "\":\",line,\" \",msg,\"\\n\"].",
+            ?DEFAULT_FILTERS_CFGKEY =>
+                [crash, error, sasl, backend, background],
+            ?ADDITIONAL_HANDLERS_CFGKEY =>
+                [crash, error, report, backend, background]
+        },
+    {ok, DomainConfig} = handler_config(Conf1, ConfFetchFun),
+
+    ClassicConfig = expected_classic_config(),
+    [DefaultHandler|OtherHandlers] = ClassicConfig,
+    {H, N, T, M} = DefaultHandler,
+    ExpectedFilters =
+        [
+            {
+                backend_filter,
+                {fun logger_filters:domain/2, {stop, sub, [backend]}}
+            },
+            {
+                background_filter,
+                {fun logger_filters:domain/2, {stop, sub, [background]}}
+            },
+            {default_filter, {fun riak_logger:filter_ces/2, stop}}
+        ],
+    UpdM = maps:put(filters, ExpectedFilters, M),
+    ExpectedDefaultHandler = {H, N, T, UpdM},
+    ExpectedBackendHandler =
+        {
+            handler,
+            backend,
+            logger_std_h,
+            #{
+                level => all,
+                config =>
+                    standard_config("/var/log/riak/backend.log", 1048576, 10),
+                filter_default => stop,
+                filters => 
+                    [
+                        {
+                            domain_filter,
+                            {fun logger_filters:domain/2, {log, sub, [backend]}}
+                        }
+                    ],
+                formatter =>
+                    {
+                        logger_formatter,
+                        standard_formatter(true, standard_template())
+                    }
+            }
+        },
+    ExpectedAsyncHandler =
+        {
+            handler,
+            background,
+            logger_std_h,
+            #{
+                level => all,
+                config =>
+                    standard_config("/var/log/riak/async.log", 1048576, 10),
+                filter_default => stop,
+                filters => 
+                    [
+                        {
+                            domain_filter, 
+                            {fun logger_filters:domain/2, {log, sub, [background]}}
+                        }
+                    ],
+                formatter =>
+                    {
+                        logger_formatter,
+                        standard_formatter(true, standard_template())
+                    }
+            }
+        },
+
+    ExpectedHandlers =
+        [ExpectedDefaultHandler|OtherHandlers] ++ 
+        [ExpectedBackendHandler, ExpectedAsyncHandler],
+
+    ?assertMatch(ExpectedHandlers, DomainConfig).
+
+-endif.

--- a/src/riak_logger_config.erl
+++ b/src/riak_logger_config.erl
@@ -120,14 +120,8 @@ conf_getlist(Key, ConfFetchFun, Conf) ->
     string(), config_fetch_fun(), config_map()) -> list(atom()).
 conf_getatomlist(Key, ConfFetchFun, Conf) ->
     case ConfFetchFun(Key, Conf) of
-        L when erlang:is_list(L) ->
-            Tokens = string:lexemes(L, "|"),
-            lists:map(
-                fun(T) -> 
-                    erlang:list_to_atom(string:lowercase(T))
-                end,
-                Tokens
-            )
+        AL when erlang:is_list(AL) ->
+            AL
     end.
 
 -spec parse_inputs(config_fetch_fun(), config_map()) ->
@@ -527,8 +521,8 @@ classic_config_test() ->
             ?DEFAULT_FORMAT_CFGKEY => 
                 "[time,\" [\",level,\"] \",pid,\"@\",mfa,"
                 "\":\",line,\" \",msg,\"\\n\"].",
-            ?DEFAULT_FILTERS_CFGKEY => "crash|error|sasl",
-            ?ADDITIONAL_HANDLERS_CFGKEY => "crash|error|report"
+            ?DEFAULT_FILTERS_CFGKEY => [crash, error, sasl],
+            ?ADDITIONAL_HANDLERS_CFGKEY => [crash, error, report]
         },
     {ok, ClassicConfig} = handler_config(Conf1, ConfFetchFun),
 
@@ -662,8 +656,8 @@ json_config_test() ->
             ?DEFAULT_FORMAT_CFGKEY => 
                 "[time,\" [\",level,\"] \",pid,\"@\",mfa,"
                 "\":\",line,\" \",msg,\"\\n\"].",
-            ?DEFAULT_FILTERS_CFGKEY => "crash|error|sasl",
-            ?ADDITIONAL_HANDLERS_CFGKEY => "crash|error|report|json"
+            ?DEFAULT_FILTERS_CFGKEY => [crash, error, sasl],
+            ?ADDITIONAL_HANDLERS_CFGKEY => [crash, error, report, json]
         },
     {ok, JsonConfig} = handler_config(Conf1, ConfFetchFun),
 
@@ -708,9 +702,9 @@ domain_config_test() ->
                 "[time,\" [\",level,\"] \",pid,\"@\",mfa,"
                 "\":\",line,\" \",msg,\"\\n\"].",
             ?DEFAULT_FILTERS_CFGKEY =>
-                "crash|error|sasl|backend|background",
+                [crash, error, sasl, backend, background],
             ?ADDITIONAL_HANDLERS_CFGKEY =>
-                "crash|error|report|backend|background"
+                [crash, error, report, backend, background]
         },
     {ok, DomainConfig} = handler_config(Conf1, ConfFetchFun),
 


### PR DESCRIPTION
Add a function to generate handlers for logging in Riak.

The function will allow for a config to be passed in (with a fetch fun to fetch a value from config).  The expected keys in the config are in `riak_logger_config.hrl`.  The config will allow for:

- A default template to be set for logs;
- The max number of files and size of those files (will be consistent across all handlers);
- A file path for each handler;
- A list of default filters i.e. filters to be applied to exclude results from the default log handler;
- A list of additional handlers i.e. filters to be provided in addition to the default handler.

Logs can be ignored by adding a default filter without adding an additional handler.